### PR TITLE
add pry-nav, from ASC to DESC in Daily Scrums by Sprint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,4 +51,8 @@ gem 'redcarpet'
 # gem 'capistrano-rails', group: :development
 
 # Use debugger
-gem 'pry', group: [:development, :test]
+# gem 'pry', group: [:development, :test]
+group :development, :test do
+  gem 'pry'
+  gem 'pry-nav'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,8 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    pry-nav (0.2.4)
+      pry (>= 0.9.10, < 0.11.0)
     rack (1.5.2)
     rack-test (0.6.2)
       rack (>= 1.0)
@@ -157,6 +159,7 @@ DEPENDENCIES
   less-rails
   pg
   pry
+  pry-nav
   rails (= 4.1.1)
   redcarpet
   sass-rails (~> 4.0.3)

--- a/app/controllers/daily_scrums_controller.rb
+++ b/app/controllers/daily_scrums_controller.rb
@@ -68,7 +68,7 @@ class DailyScrumsController < ApplicationController
     @all_scrums = DailyScrum.where(:sprint_id => sprint_selection).order('scrum_date ASC')
 
     #Return all unique dates to group scrums
-    @date_headers = DailyScrum.select(:scrum_date).distinct.where(:sprint_id => sprint_selection).order('scrum_date ASC')
+    @date_headers = DailyScrum.select(:scrum_date).distinct.where(:sprint_id => sprint_selection).order('scrum_date DESC')
 
     #render the csv
     respond_to do |format|


### PR DESCRIPTION
1. add 'pry-nav' gem
2. change the order from ASC to DESC in Daily Scrums by Sprint
