### PR TITLE
Sunset users

### DIFF
--- a/db/migrate/20150416185849_add_active_users_to_users.rb
+++ b/db/migrate/20150416185849_add_active_users_to_users.rb
@@ -1,0 +1,9 @@
+class AddActiveUsersToUsers < ActiveRecord::Migration
+  def self.up
+    add_column :users, :is_active, :boolean
+  end
+
+  def self.down
+    remove_column :users, :is_active
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141014140751) do
+ActiveRecord::Schema.define(version: 20150416185849) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -50,6 +50,7 @@ ActiveRecord::Schema.define(version: 20141014140751) do
     t.boolean  "admin"
     t.string   "user_tz"
     t.string   "user_irc_nick"
+    t.boolean  "is_active"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree


### PR DESCRIPTION
Added a feature to allow for an admin to set a user as active/inactive. This is particularly useful for the cucubot, which will check if a user is active, and then proceed to ping that user with a reminder to fill out their scrum for the day. 